### PR TITLE
fix: expose type declarations

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,8 @@
   "exports": {
     ".": {
       "import": "./dist/lib.es.js",
-      "require": "./dist/lib.umd.js"
+      "require": "./dist/lib.umd.js",
+      "types": "./dist/lib.d.ts"
     }
   },
   "scripts": {

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -12,7 +12,8 @@
   "exports": {
     ".": {
       "import": "./dist/lib.es.js",
-      "require": "./dist/lib.umd.js"
+      "require": "./dist/lib.umd.js",
+      "types": "./dist/lib.d.ts"
     }
   },
   "scripts": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -12,7 +12,8 @@
   "exports": {
     ".": {
       "import": "./dist/lib.es.js",
-      "require": "./dist/lib.umd.js"
+      "require": "./dist/lib.umd.js",
+      "types": "./dist/lib.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
Hello 👋🏻 

This PR fixes `exports` definition in `package.json` files.

When importing package TS is not able to resolve the path to the file with types declaration.

That results in following error:

```
src/modules/login/login.store.ts:1:28 - error TS7016: Could not find a declaration file for module '@deepsignal/preact'. '/Users/patryklizon/Developer/yallo/node_modules/@deepsignal/preact/dist/lib.es.js' implicitly has an 'any' type.
  There are types at '/Users/patryklizon/Developer/yallo/node_modules/@deepsignal/preact/dist/lib.d.ts', but this result could not be resolved when respecting package.json "exports". The '@deepsignal/preact' library may need to update its package.json or typings.

1 import { deepSignal } from "@deepsignal/preact";
```

Webpack docs on package exports: https://webpack.js.org/guides/package-exports/